### PR TITLE
Pequeño cambio sugerido

### DIFF
--- a/EA1/ACT1.1/provider.tf
+++ b/EA1/ACT1.1/provider.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
 }


### PR DESCRIPTION
# El bloque terraform{} declara de dónde bajar el provider y qué versión usar.
# Sin él, Terraform infiere todo automáticamente pero sin control de versión.

# source  → registry oficial (necesario para providers privados o de terceros)
# version → fija rango compatible: acepta 4.x, rechaza 5.0+ (evita breaking changes)
# Obligatorio desde Terraform 0.13+ para providers no oficiales. Siempre es buena práctica.